### PR TITLE
execute payment by anyone

### DIFF
--- a/Vault.sol
+++ b/Vault.sol
@@ -197,7 +197,6 @@ contract Vault is Escapable {
 
         Payment payment = payments[_idPayment];
 
-        if (msg.sender != payment.recipient) throw;
         if (!allowedSpenders[payment.spender]) throw;
         if (now < payment.earliestPayTime) throw;
         if (payment.cancelled) throw;


### PR DESCRIPTION
Most contracts don't have the ability (also for security reasons) to call arbitrary functions. So it should be possible to call `executePayment` from another contract/address than the reciever.